### PR TITLE
Updated parent POM and workflows to take advantage of new Central Repo Portal

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -78,8 +78,8 @@ jobs:
                     maven-stable-artifact-phases: clean,site,site:stage,deploy
                     documentation-dir: target/staging/mi-label
                 env:
-                    ossrh_username: ${{secrets.OSSRH_USERNAME}}
-                    ossrh_password: ${{secrets.OSSRH_PASSWORD}}
+                    central_portal_username: ${{secrets.CENTRAL_REPOSITORY_USERNAME}}
+                    central_portal_token: ${{secrets.CENTRAL_REPOSITORY_TOKEN}}
                     CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -80,8 +80,8 @@ jobs:
                     maven-doc-phases: clean,site,site:stage
                     maven-unstable-artifact-phases: clean,site,site:stage,deploy
                 env:
-                    ossrh_username: ${{secrets.OSSRH_USERNAME}}
-                    ossrh_password: ${{secrets.OSSRH_PASSWORD}}
+                    central_portal_username: ${{secrets.CENTRAL_REPOSITORY_USERNAME}}
+                    central_portal_token: ${{secrets.CENTRAL_REPOSITORY_TOKEN}}
                     CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>gov.nasa</groupId>
-      <artifactId>pds</artifactId>
-      <version>1.18.0</version>
+      <groupId>gov.nasa.pds</groupId>
+      <artifactId>parent</artifactId>
+      <version>1.19.0</version>
     </parent>
     
     <groupId>gov.nasa.pds</groupId>


### PR DESCRIPTION
## 🗒️ Summary

The older [OSSRH is being decommissioned in favor of the new Maven Central Repository Portal](https://github.com/NASA-PDS/software-issues-repo/issues/128). The parent POM now takes advantage of it and has been published, and the Roundup Action uses new variables.

For this repository to do the same, it must inherit from the new parent POM and update the Roundup workflows. Merge this to achieve that.

## ⚙️ Test Data and/or Report

Not applicable; however any checks that fail below are likely orthogonal to this change.

## ♻️ Related Issues

- https://github.com/NASA-PDS/software-issues-repo/issues/128
- https://github.com/NASA-PDS/software-issues-repo/issues/131

